### PR TITLE
[WIP] Changes for TYPO3 9

### DIFF
--- a/Classes/Hook/BackendHook.php
+++ b/Classes/Hook/BackendHook.php
@@ -4,6 +4,7 @@ namespace PeterBenke\PbNotifications\Hook;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Backend\Controller\BackendController;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\Page\PageRenderer;
 
 /**
  * Class BackendHook
@@ -53,9 +54,11 @@ class BackendHook{
 			'reminderMessage' => $this->translate('reminder.message'),
 		];
 
-		//$backendReference->addJavascript('TYPO3.LLL.pbNotifications = ' . json_encode($labels) . ';');
-        $js = 'TYPO3.LLL.pbNotifications = ' . json_encode($labels) . ';';
-        $pageRenderer->addJsInlineCode('PbNotificationsInlineJavascript', $js, false);
+		// for TYPO3 9:
+        // https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/9.0/Breaking-83161-RemoveTYPO3LLLUsagesInTYPO3Core.html
+        $pageRenderer = GeneralUtility::makeInstance(PageRenderer::class);
+        $pageRenderer->addInlineLanguageLabelFile('EXT:pb_notifications/Resources/Private/Language/locallang.xlf');
+
 
 		$pageRenderer->loadRequireJsModule(
 			// => pb_notifications/Resources/Public/JavaScript/Reminder/Reminder.js

--- a/Classes/Hook/BackendHook.php
+++ b/Classes/Hook/BackendHook.php
@@ -53,7 +53,9 @@ class BackendHook{
 			'reminderMessage' => $this->translate('reminder.message'),
 		];
 
-		$backendReference->addJavascript('TYPO3.LLL.pbNotifications = ' . json_encode($labels) . ';');
+		//$backendReference->addJavascript('TYPO3.LLL.pbNotifications = ' . json_encode($labels) . ';');
+        $js = 'TYPO3.LLL.pbNotifications = ' . json_encode($labels) . ';';
+        $pageRenderer->addJsInlineCode('PbNotificationsInlineJavascript', $js, false);
 
 		$pageRenderer->loadRequireJsModule(
 			// => pb_notifications/Resources/Public/JavaScript/Reminder/Reminder.js

--- a/Classes/Utility/ExtensionConfigurationUtility.php
+++ b/Classes/Utility/ExtensionConfigurationUtility.php
@@ -34,15 +34,21 @@ class ExtensionConfigurationUtility{
 	 */
 	public static function getCurrentConfiguration(){
 
-		/**
-		 * @var \TYPO3\CMS\Extbase\Object\ObjectManager $objectManager
-		 * @var \TYPO3\CMS\Extensionmanager\Utility\ConfigurationUtility $configurationUtility
-		 */
-		$objectManager = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\\CMS\\Extbase\\Object\\ObjectManager');
-		$configurationUtility = $objectManager->get('TYPO3\CMS\Extensionmanager\Utility\ConfigurationUtility');
+        if (version_compare(TYPO3_version, '9.5', '<')) {
 
-		$extensionConfiguration = $configurationUtility->getCurrentConfiguration('pb_notifications');
-		return $extensionConfiguration;
+            /**
+             * @var \TYPO3\CMS\Extbase\Object\ObjectManager $objectManager
+             * @var \TYPO3\CMS\Extensionmanager\Utility\ConfigurationUtility $configurationUtility
+             */
+            $objectManager = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\\CMS\\Extbase\\Object\\ObjectManager');
+            $configurationUtility = $objectManager->get('TYPO3\CMS\Extensionmanager\Utility\ConfigurationUtility');
+
+            $extensionConfiguration = $configurationUtility->getCurrentConfiguration('pb_notifications');
+            return $extensionConfiguration;
+        } else {
+            return \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Configuration\ExtensionConfiguration::class)
+                ->get('pb_notifications');
+        }
 
 	}
 
@@ -53,7 +59,11 @@ class ExtensionConfigurationUtility{
 	public static function getNotificationsStoragePid(){
 
 		$configuration = self::getCurrentConfiguration();
-		return $configuration['notificationsStoragePid']['value'];
+        if (version_compare(TYPO3_version, '9.5', '<')) {
+            return $configuration['notificationsStoragePid']['value'];
+        } else {
+            return $configuration['notificationsStoragePid'];
+        }
 
 	}
 
@@ -64,7 +74,11 @@ class ExtensionConfigurationUtility{
 	public static function getMaxNumberOfNotificationsInToolbar(){
 
 		$configuration = self::getCurrentConfiguration();
-		return $configuration['maxNumberOfNotificationsInToolbar']['value'];
+        if (version_compare(TYPO3_version, '9.5', '<')) {
+            return $configuration['maxNumberOfNotificationsInToolbar']['value'];
+        } else {
+            return $configuration['maxNumberOfNotificationsInToolbar'];
+        }
 
 	}
 

--- a/Classes/ViewHelpers/CountUnreadNotificationsViewHelper.php
+++ b/Classes/ViewHelpers/CountUnreadNotificationsViewHelper.php
@@ -2,14 +2,18 @@
 
 namespace PeterBenke\PbNotifications\ViewHelpers;
 
-class CountUnreadNotificationsViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper {
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
-	/**
-	 * Render
-	 * @param $notifications \TYPO3\CMS\Extbase\Persistence\ObjectStorage<\PeterBenke\PbNotifications\Domain\Model\Notification>
-	 * @return int
-	 */
-	protected static function render(\TYPO3\CMS\Extbase\Persistence\ObjectStorage $notifications) {
+class CountUnreadNotificationsViewHelper extends AbstractViewHelper {
+
+
+    public function initializeArguments()
+    {
+        $this->registerArgument('notifications', \TYPO3\CMS\Extbase\Persistence\ObjectStorage::class, 'Notifications', false);
+    }
+
+	public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext) {
 
 		/**
 		 * @var $notification \PeterBenke\PbNotifications\Domain\Model\Notification
@@ -21,8 +25,8 @@ class CountUnreadNotificationsViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelpe
 
 		$unreadNotifications = 0;
 
-		if(isset($notifications)){
-			foreach($notifications as $notification){
+		if(isset($arguments['notifications'])){
+			foreach($arguments['notifications'] as $notification){
 
 				$markedAsReadObjects = $notification->getMarkedAsRead();
 				$markedAsRead = array();

--- a/Classes/ViewHelpers/IfMarkedAsReadViewHelper.php
+++ b/Classes/ViewHelpers/IfMarkedAsReadViewHelper.php
@@ -2,7 +2,10 @@
 
 namespace PeterBenke\PbNotifications\ViewHelpers;
 
-class IfMarkedAsReadViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper {
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+
+class IfMarkedAsReadViewHelper extends AbstractConditionViewHelper {
 
 	/**
 	 * Initialize arguments
@@ -18,7 +21,7 @@ class IfMarkedAsReadViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\Abstract
 	 * @param array|null $arguments
 	 * @return bool
 	 */
-	protected static function evaluateCondition($arguments = null) {
+	public static function verdict(array $arguments, RenderingContextInterface $renderingContext) {
 
 		/**
 		 * @var $beUserMarkedAsRead \TYPO3\CMS\Beuser\Domain\Model\BackendUser

--- a/Classes/ViewHelpers/IfUnreadNotificationsExistViewHelper.php
+++ b/Classes/ViewHelpers/IfUnreadNotificationsExistViewHelper.php
@@ -2,7 +2,10 @@
 
 namespace PeterBenke\PbNotifications\ViewHelpers;
 
-class IfUnreadNotificationsExistViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper {
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+
+class IfUnreadNotificationsExistViewHelper extends AbstractConditionViewHelper {
 
 	/**
 	 * Initialize arguments
@@ -18,7 +21,7 @@ class IfUnreadNotificationsExistViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHel
 	 * @param array|null $arguments
 	 * @return bool
 	 */
-	protected static function evaluateCondition(array $arguments = null) {
+	public static function verdict(array $arguments, RenderingContextInterface $renderingContext) {
 
 		/**
 		 * @var $notification \PeterBenke\PbNotifications\Domain\Model\Notification

--- a/Classes/ViewHelpers/Widget/PaginateViewHelper.php
+++ b/Classes/ViewHelpers/Widget/PaginateViewHelper.php
@@ -33,7 +33,7 @@ use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
 use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
 use TYPO3\CMS\Fluid\Core\Widget\AbstractWidgetViewHelper;
 
-class PaginateViewHelper extends \TYPO3\CMS\Fluid\Core\Widget\AbstractWidgetViewHelper{
+class PaginateViewHelper extends AbstractWidgetViewHelper{
 
 	/**
 	 * @var \PeterBenke\PbNotifications\ViewHelpers\Widget\Controller\PaginateController
@@ -49,24 +49,13 @@ class PaginateViewHelper extends \TYPO3\CMS\Fluid\Core\Widget\AbstractWidgetView
 	public function injectController(\PeterBenke\PbNotifications\ViewHelpers\Widget\Controller\PaginateController $controller)
 	{
 		$this->controller = $controller;
+        $this->registerArgument('objects', \TYPO3\CMS\Extbase\Persistence\ObjectStorage::class, 'Objects', true);
+        $this->registerArgument('as', 'string', 'as', true);
+        $this->registerArgument('configuration', 'array', 'configuration', true);
+        $this->registerArgument('initial', 'array', 'initial', false);
 	}
 
-	/**
-	 * Render everything
-	 *
-	 * @param \TYPO3\CMS\Extbase\Persistence\ObjectStorage $objects
-	 * @param string $as
-	 * @param mixed $configuration
-	 * @param array $initial
-	 * @internal param array $initial
-	 * @return string
-	 */
-	public function render(
-		$objects,
-		$as,
-		$configuration = ['itemsPerPage' => 10, 'insertAbove' => false, 'insertBelow' => true],
-		$initial = []
-	) {
+	public function render() {
 		return $this->initiateSubRequest();
 	}
 }

--- a/Configuration/TCA/tx_pbnotifications_domain_model_notification.php
+++ b/Configuration/TCA/tx_pbnotifications_domain_model_notification.php
@@ -20,7 +20,7 @@ return array(
 			'endtime' => 'endtime',
 		),
 		'searchFields' => 'title,content,type,marked_as_read,',
-		'iconfile' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extRelPath('pb_notifications') . 'Resources/Public/Icons/tx_pbnotifications_domain_model_notification.svg'
+		'iconfile' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('pb_notifications') . 'Resources/Public/Icons/tx_pbnotifications_domain_model_notification.svg'
 	),
 	'interface' => array(
 		'showRecordFieldList' => 'sys_language_uid, l10n_parent, l10n_diffsource, hidden, date, type, title, content, images, be_groups, marked_as_read',

--- a/Resources/Public/JavaScript/Reminder/Reminder.js
+++ b/Resources/Public/JavaScript/Reminder/Reminder.js
@@ -11,8 +11,8 @@ define(['jquery', 'TYPO3/CMS/Backend/Modal'], function ($, Modal) {
 
         $(function () {
 			Modal.show(
-				TYPO3.LLL.pbNotifications.reminderTitle,
-				TYPO3.LLL.pbNotifications.reminderMessage,
+				TYPO3.lang['reminder.title'],
+				TYPO3.lang['reminder.message'],
 				TYPO3.Severity.warning,
 				[{
 					text: TYPO3.lang['button.ok'] || 'OK',

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "GPL-2.0+"
   ],
   "require": {
-    "typo3/cms-core": ">=7.6.0 <9"
+    "typo3/cms-core": ">=8.7.0 <= 9.5"
   },
   "autoload": {
     "psr-4": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -14,7 +14,7 @@ $EM_CONF[$_EXTKEY] = array(
 	'version' => '1.1.8',
 	'constraints' => array(
 		'depends' => array(
-			'typo3' => '8.7.0 - 9.5.99',
+			'typo3' => '9.5.9 - 9.5.99',
 		),
 		'conflicts' => array(
 		),

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -11,10 +11,10 @@ $EM_CONF[$_EXTKEY] = array(
 	'uploadfolder' => '0',
 	'createDirs' => '',
 	'clearCacheOnLoad' => 0,
-	'version' => '1.1.7',
+	'version' => '1.1.8',
 	'constraints' => array(
 		'depends' => array(
-			'typo3' => '7.6.0-8.7.99',
+			'typo3' => '8.7.0 - 9.5.99',
 		),
 		'conflicts' => array(
 		),


### PR DESCRIPTION
**This patch will only work for 9.5.** 

It's probably best to create seperate branches / releases for the versions.

I did some tests on 9.5.9 but did not thoroughly test yet, hence the WIP.

1. getRecordRaw

breaking in 9, deprecated in 8

https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/8.7/Deprecation-80317-DeprecateBackendUtilityGetRecordRaw.html
https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/9.0/Breaking-80700-DeprecatedFunctionalityRemoved.html

2. BackendController inclusion hooks

deprecation in 8, breaking in 9

https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/9.0/Breaking-80700-DeprecatedFunctionalityRemoved.html
https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/8.7/Deprecation-80491-BackendControllerInclusionHooks.html

3. AbstractViewHelper usw. from  TYPO/CMS/

deprecated + breaking in 9

https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/9.0/Breaking-82414-RemoveCMSBaseViewHelperClasses.html
https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/9.5.x/Deprecation-87277-FluidClassAliases.html

4. render() method arguments

https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/9.0/Breaking-82414-RemoveCMSBaseViewHelperClasses.html
https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/9.5.x/Deprecation-87277-FluidClassAliases.html

5. JavaScript Language handling

* https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/9.0/Breaking-83161-RemoveTYPO3LLLUsagesInTYPO3Core.html