### PR TITLE
Fix license string in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "license": [
-        "GPL-2.0+"
+        "GPL-2.0-or-later"
     ],
     "require": {
         "typo3/cms-core": "^11.5"


### PR DESCRIPTION
Previously, "GPL-2.0+" was used which is a
deprecated license identifier and results in a warning message
(with "composer validate").

"GPL-2.0-or-later" should be used.

Resolves: #2