### PR TITLE
!!![TASK] Make ready for TYPO3 v12

### DIFF
--- a/Classes/EventListener/AfterBackendPageRenderEventListener.php
+++ b/Classes/EventListener/AfterBackendPageRenderEventListener.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+namespace PeterBenke\PbNotifications\EventListener;
+
+use PeterBenke\PbNotifications\Domain\Repository\NotificationRepository;
+use PeterBenke\PbNotifications\Utility\ExtensionConfigurationUtility;
+use TYPO3\CMS\Backend\Controller\Event\AfterBackendPageRenderEvent;
+use TYPO3\CMS\Core\Page\PageRenderer;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+final readonly class AfterBackendPageRenderEventListener
+{
+    public function __invoke(AfterBackendPageRenderEvent $event): void
+    {
+        // Create objects
+        /** @var NotificationRepository $notificationRepository */
+        $notificationRepository = GeneralUtility::makeInstance(NotificationRepository::class);
+
+        // Only unread notifications
+        $unreadNotifications = $notificationRepository->findOnlyUnreadNotificationsAssignedToUsersUserGroup();
+
+        // We do not need to show a popup to the user after login
+        if($unreadNotifications->count() === 0 || !ExtensionConfigurationUtility::forcePopupAfterLogin()){
+            return;
+        }
+
+        /** @var PageRenderer $pageRenderer */
+        $pageRenderer = GeneralUtility::makeInstance(PageRenderer::class);
+        $pageRenderer->addInlineLanguageLabelFile('EXT:pb_notifications/Resources/Private/Language/locallang.xlf');
+        $pageRenderer->loadRequireJsModule(
+            'TYPO3/CMS/PbNotifications/Reminder/Reminder',
+            'function(reminder){
+                reminder.initModal(true);
+            }'
+        );
+    }
+}

--- a/Classes/Hook/BackendHook.php
+++ b/Classes/Hook/BackendHook.php
@@ -15,6 +15,8 @@ use TYPO3\CMS\Core\Page\PageRenderer;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
+ * @todo Only used for v11, remove when support for v11 is dropped, use event listener for \TYPO3\CMS\Backend\Controller\Event\AfterBackendPageRenderEvent instead
+ *
  * Class BackendHook
  * @author Peter Benke <info@typomotor.de>
  */

--- a/Classes/ViewHelpers/Widget/PaginateViewHelper.php
+++ b/Classes/ViewHelpers/Widget/PaginateViewHelper.php
@@ -159,16 +159,6 @@ class PaginateViewHelper extends AbstractViewHelper
      */
     protected static function getPageNumber(RenderingContextInterface $renderingContext): int
     {
-        /**
-         * @todo ControllerContext is deprecated in v11 and removed in v12
-         *
-         * 11.5 Deprecation: #95139 - Extbase ControllerContext
-         *   https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.5/Deprecation-95139-ExtbaseControllerContext.html
-         * 12.0 Breaking: #96107 - Deprecated functionality removed
-         *
-         * Migration:
-         * - Method getRequest() is available in controllers directly, and view-helpers receive the current request by calling RenderingContext->getRequest().
-         */
         $request = null;
         if (method_exists($renderingContext, 'getRequest')) {
             $request = $renderingContext->getRequest();

--- a/Classes/ViewHelpers/Widget/PaginateViewHelper.php
+++ b/Classes/ViewHelpers/Widget/PaginateViewHelper.php
@@ -159,10 +159,35 @@ class PaginateViewHelper extends AbstractViewHelper
      */
     protected static function getPageNumber(RenderingContextInterface $renderingContext): int
     {
-        $extensionName = $renderingContext->getControllerContext()->getRequest()->getControllerExtensionName();
-        $pluginName = $renderingContext->getControllerContext()->getRequest()->getPluginName();
+        /**
+         * @todo ControllerContext is deprecated in v11 and removed in v12
+         *
+         * 11.5 Deprecation: #95139 - Extbase ControllerContext
+         *   https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.5/Deprecation-95139-ExtbaseControllerContext.html
+         * 12.0 Breaking: #96107 - Deprecated functionality removed
+         *
+         * Migration:
+         * - Method getRequest() is available in controllers directly, and view-helpers receive the current request by calling RenderingContext->getRequest().
+         */
+        $request = null;
+        if (method_exists($renderingContext, 'getRequest')) {
+            $request = $renderingContext->getRequest();
+        }
+
+        if (!$request) {
+            return 0;
+        }
+
+        $extensionName = $request->getControllerExtensionName();
+        $pluginName = $request->getPluginName();
         $extensionService = GeneralUtility::makeInstance(ExtensionService::class);
         $pluginNamespace = $extensionService->getPluginNamespace($extensionName, $pluginName);
+
+        /**
+         * @todo _GP is deprecated in v12
+         *
+         *   Deprecation: #100053 - GeneralUtility::_GP()
+         */
         $variables = GeneralUtility::_GP($pluginNamespace);
         if ($variables !== null) {
             if (!empty($variables['currentPage'])) {

--- a/Configuration/Backend/Modules.php
+++ b/Configuration/Backend/Modules.php
@@ -1,0 +1,24 @@
+<?php
+
+return [
+    //'user_notifications' => [
+    'user_PbNotificationsNotifications' => [
+        // Make module a submodule of 'user'
+        'parent' => 'user',
+        'position' => ['after' => 'web_info'],
+        'access' => 'use,group',
+        'workspaces' => 'live',
+        'iconIdentifier' => 'tx-pb_notifications-module',
+        'path' => '/module/user/notifications',
+        'labels' => 'LLL:EXT:pb_notifications/Resources/Private/Language/locallang.xlf:module.notifications.title',
+        'extensionName' => 'pb_notifications',
+        'controllerActions' => [
+            \PeterBenke\PbNotifications\Controller\NotificationController::class => [
+                'list',
+                'show',
+                'markAsRead',
+                'markAsUnread',
+            ],
+        ],
+    ],
+];

--- a/Configuration/Backend/Modules.php
+++ b/Configuration/Backend/Modules.php
@@ -5,8 +5,7 @@ return [
     'user_PbNotificationsNotifications' => [
         // Make module a submodule of 'user'
         'parent' => 'user',
-        'position' => ['after' => 'web_info'],
-        'access' => 'use,group',
+        'access' => 'user',
         'workspaces' => 'live',
         'iconIdentifier' => 'tx-pb_notifications-module',
         'path' => '/module/user/notifications',

--- a/Configuration/Icons.php
+++ b/Configuration/Icons.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+use TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider;
+
+return [
+    // Icon identifier
+    'tx-pb_notifications-module' => [
+        // Icon provider class
+        'provider' => SvgIconProvider::class,
+        // The source SVG for the SvgIconProvider
+        'source' => 'EXT:pb_notifications/Resources/Public/Icons/bell-orange.svg',
+    ],
+];

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -1,0 +1,14 @@
+services:
+  _defaults:
+    autowire: true
+    autoconfigure: true
+    public: false
+
+  PeterBenke\PbNotifications\:
+    resource: '../Classes/*'
+
+  # event listeners
+  PeterBenke\PbNotifications\EventListener\AfterBackendPageRenderEventListener:
+    tags:
+      - name: event.listener
+        identifier: 'pb_notifications/backend/after-backend-page-render'

--- a/Configuration/TCA/tx_pbnotifications_domain_model_notification.php
+++ b/Configuration/TCA/tx_pbnotifications_domain_model_notification.php
@@ -19,6 +19,10 @@ return [
 		],
         'searchFields' => 'title,content,type,marked_as_read,',
         'iconfile' => 'EXT:pb_notifications/Resources/Public/Icons/tx_pbnotifications_domain_model_notification.svg',
+        'security' => [
+            'ignorePageTypeRestriction' => true,
+            ],
+        ],
     ],
     'types' => [
         '1' => [

--- a/Configuration/TCA/tx_pbnotifications_domain_model_notification.php
+++ b/Configuration/TCA/tx_pbnotifications_domain_model_notification.php
@@ -20,8 +20,7 @@ return [
         'searchFields' => 'title,content,type,marked_as_read,',
         'iconfile' => 'EXT:pb_notifications/Resources/Public/Icons/tx_pbnotifications_domain_model_notification.svg',
         'security' => [
-            'ignorePageTypeRestriction' => true,
-            ],
+                'ignorePageTypeRestriction' => true,
         ],
     ],
     'types' => [

--- a/Configuration/TCA/tx_pbnotifications_domain_model_notification.php
+++ b/Configuration/TCA/tx_pbnotifications_domain_model_notification.php
@@ -140,6 +140,9 @@ return [
         'images' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:pb_notifications/Resources/Private/Language/locallang_db.xlf:tx_pbnotifications_domain_model_notification.images',
+            /**
+             * @todo getFileFieldTCAConfig is deprecated in v12
+             */
             'config' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getFileFieldTCAConfig(
                 'images',
                 [

--- a/Resources/Private/Layouts/Default.html
+++ b/Resources/Private/Layouts/Default.html
@@ -1,42 +1,29 @@
-<f:be.container includeCssFiles="{0: '{f:uri.resource(path:\'Css/notifications.css\')}', 1: '{f:uri.resource(path:\'Css/prettyPhoto.css\')}'}" includeJsFiles="{0: '{f:uri.resource(path:\'JavaScript/List/jquery-3.6.0.min.js\')}', 1: '{f:uri.resource(path:\'JavaScript/List/jquery.prettyPhoto-manipulated.js\')}', 2: '{f:uri.resource(path:\'JavaScript/List/notifications.js\')}'}">
-	<div class="typo3-fullDoc">
-		<div id="typo3-docheader">
+<f:comment>
+    added in Controller as module:
+    0: 'EXT:pb_notifications/Resources/Public/JavaScript/List/jquery.prettyPhoto-manipulated.js
 
-			<div class="typo3-docheader-functions">
-				<div class="left">
-					<f:comment>
-						<!--
-						<f:be.buttons.csh />
-						<f:be.menus.actionMenu>
-							<f:be.menus.actionMenuItem label="Overview" controller="" action="list" />
-							<f:be.menus.actionMenuItem label="Create new Tool" action="new" controller="Tool" />
-						</f:be.menus.actionMenu>
-						-->
-					</f:comment>
-				</div>
-				<div class="right">
-					<f:be.pagePath />
-					<f:be.pageInfo />
-				</div>
-			</div>
+    todo: this should be loaded as module as well (or used other method to make jquery available, is currently not loaded
+    1: 'EXT:pb_notifications/Resources/Public/JavaScript/List/notifications.js'
+</f:comment>
+<f:be.pageRenderer
+    includeCssFiles="{0: 'EXT:pb_notifications/Resources/Public/Css/notifications.css', 1: 'EXT:pb_notifications/Resources/Public/Css/prettyPhoto.css'}"
+/>
+<div class="typo3-fullDoc">
+    <div id="typo3-docheader">
 
-			<f:comment>
-				<!--
-							<div class="typo3-docheader-buttons">
-								<div class="left">
-								</div>
-								<div class="right">
-									<f:be.buttons.shortcut />
-								</div>
-							</div>
-				-->
-			</f:comment>
+        <div class="typo3-docheader-functions">
+            <div class="left">
+            </div>
+            <div class="right">
+                <f:be.pagePath />
+                <f:be.pageInfo />
+            </div>
+        </div>
 
-		</div>
-		<div id="typo3-docbody">
-			<div id="typo3-inner-docbody" class="tx_pb-notifications">
-				<f:render section="content" />
-			</div>
-		</div>
-	</div>
-</f:be.container>
+    </div>
+    <div id="typo3-docbody">
+        <div id="typo3-inner-docbody" class="tx_pb-notifications">
+            <f:render section="content" />
+        </div>
+    </div>
+</div>

--- a/Resources/Private/Partials/Pagination.html
+++ b/Resources/Private/Partials/Pagination.html
@@ -19,10 +19,10 @@
             <li class="page-item previous">
                 <f:if condition="{pagination.previousPage} > 1">
                     <f:then>
-                        <f:link.action class="page-link" arguments="{currentPage: pagination.previousPage}" addQueryStringMethod="{configuration.addQueryStringMethod}" section="{configuration.section}"><f:translate key="widget.pagination.previous" /></f:link.action>
+                        <f:link.action class="page-link" arguments="{currentPage: pagination.previousPage}" addQueryStringMethod="{configuration.addQueryStringMethod}" section="{configuration.section}"><f:translate key="LLL:EXT:pb_notifications/Resources/Private/Language/locallang.xlf:widget.pagination.previous" /></f:link.action>
                     </f:then>
                     <f:else>
-                        <f:link.action class="page-link" addQueryStringMethod="{configuration.addQueryStringMethod}" section="{configuration.section}"><i class="fa fa-angle-left"></i>&nbsp;<f:translate key="widget.pagination.previous" /></f:link.action>
+                        <f:link.action class="page-link" addQueryStringMethod="{configuration.addQueryStringMethod}" section="{configuration.section}"><i class="fa fa-angle-left"></i>&nbsp;<f:translate key="LLL:EXT:pb_notifications/Resources/Private/Language/locallang.xlf:widget.pagination.previous" /></f:link.action>
                     </f:else>
                 </f:if>
             </li>
@@ -66,7 +66,7 @@
         </f:if>
         <f:if condition="{pagination.nextPage}">
             <li class="page-item next">
-                <f:link.action class="page-link" arguments="{currentPage: pagination.nextPage}" addQueryStringMethod="{configuration.addQueryStringMethod}" section="{configuration.section}"><f:translate key="widget.pagination.next" />&nbsp;<i class="fa fa-angle-right"></i></f:link.action>
+                <f:link.action class="page-link" arguments="{currentPage: pagination.nextPage}" addQueryStringMethod="{configuration.addQueryStringMethod}" section="{configuration.section}"><f:translate key="LLL:EXT:pb_notifications/Resources/Private/Language/locallang.xlf:widget.pagination.next" />&nbsp;<i class="fa fa-angle-right"></i></f:link.action>
             </li>
         </f:if>
     </ul>

--- a/Resources/Private/Templates/Notification/List.html
+++ b/Resources/Private/Templates/Notification/List.html
@@ -3,7 +3,7 @@
 
 <f:section name="content">
 
-	<h1><f:translate key="notifications.list.headline" /> <f:translate key="notifications.list.headline.for" /> {f:if(condition:'{user.realName}', then: '{user.realName}', else: '{user.username}')}</h1>
+	<h1><f:translate key="LLL:EXT:pb_notifications/Resources/Private/Language/locallang.xlf:notifications.list.headline" /> <f:translate key="LLL:EXT:pb_notifications/Resources/Private/Language/locallang.xlf:notifications.list.headline.for" /> {f:if(condition:'{user.realName}', then: '{user.realName}', else: '{user.username}')}</h1>
 
 	<f:if condition="{notifications}">
 
@@ -20,7 +20,7 @@
 								</span>
 							</span>
 						</span>
-								<span><f:format.date date="{notification.date}" format="{f:translate(key:'notifications.list.dateFormat')}" /></span>
+								<span><f:format.date date="{notification.date}" format="{f:translate(key:'LLL:EXT:pb_notifications/Resources/Private/Language/locallang.xlf:notifications.list.dateFormat')}" /></span>
 							</div>
 							<div class="panel-body">
 								<h2>{notification.title}</h2>
@@ -45,10 +45,10 @@
 
 						<pb:ifMarkedAsRead markedAsRead="{notification.markedAsRead}">
 							<f:then>
-								<f:link.action class="btn btn-warning" action="markAsUnread" arguments="{uid:notification.uid}"><i class="fa fa-close"></i> <f:translate key="notifications.list.markAsUnread" /></f:link.action>
+								<f:link.action class="btn btn-warning" action="markAsUnread" arguments="{uid:notification.uid}"><i class="fa fa-close"></i> <f:translate key="LLL:EXT:pb_notifications/Resources/Private/Language/locallang.xlf:notifications.list.markAsUnread" /></f:link.action>
 							</f:then>
 							<f:else>
-								<f:link.action class="btn btn-success" action="markAsRead" arguments="{uid:notification.uid}"><i class="fa fa-check"></i> <f:translate key="notifications.list.gotit" /></f:link.action>
+								<f:link.action class="btn btn-success" action="markAsRead" arguments="{uid:notification.uid}"><i class="fa fa-check"></i> <f:translate key="LLL:EXT:pb_notifications/Resources/Private/Language/locallang.xlf:notifications.list.gotit" /></f:link.action>
 							</f:else>
 						</pb:ifMarkedAsRead>
 
@@ -62,7 +62,7 @@
 
 		<f:else>
 			<div class="alert alert-warning">
-				<i class="fa fa-info"></i> <f:translate key="notifications.list.noNotifications" />
+				<i class="fa fa-info"></i> <f:translate key="LLL:EXT:pb_notifications/Resources/Private/Language/locallang.xlf:notifications.list.noNotifications" />
 			</div>
 		</f:else>
 

--- a/Resources/Private/Templates/ToolbarMenu/DropDown.html
+++ b/Resources/Private/Templates/ToolbarMenu/DropDown.html
@@ -62,20 +62,6 @@
 	<li class="divider"></li>
 
 	<li id="pbnotifications_listnotifications">
-        <f:comment>
-            TYPO3 v12 top.gotToModule is deprecated in v11 and removed in v12
-            Deprecation: #94058 - JavaScript goToModule()
-            https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.3/Deprecation-94058-JavaScriptGoToModule.html
-
-            Use the following HTML code to replace the inline goToModule() call to for example link to the page module:
-
-            <a href="#"
-               data-dispatch-action="TYPO3.ModuleMenu.showModule"
-               data-dispatch-args-list="web_layout"
-            >
-                Go to page module
-            </a>
-        </f:comment>
 		<a href="#"
            data-dispatch-action="TYPO3.ModuleMenu.showModule"
            data-dispatch-args-list="user_PbNotificationsNotifications"

--- a/Resources/Private/Templates/ToolbarMenu/DropDown.html
+++ b/Resources/Private/Templates/ToolbarMenu/DropDown.html
@@ -1,6 +1,6 @@
 {namespace pb=PeterBenke\PbNotifications\ViewHelpers}
 
-<h3 class="dropdown-headline"><f:translate key="toolbaritem.title" /></h3>
+<h3 class="dropdown-headline"><f:translate key="LLL:EXT:pb_notifications/Resources/Private/Language/locallang.xlf:toolbaritem.title" /></h3>
 
 <ul class="dropdown-list" style="width:250px;">
 
@@ -18,7 +18,7 @@
 							<f:then>
 							<span class="text-danger">
 								<i class="fa fa-exclamation"></i>&nbsp;
-								<f:format.date date="{notification.date}" format="{f:translate(key:'notifications.list.dateFormat')}" />
+								<f:format.date date="{notification.date}" format="{f:translate(key:'LLL:EXT:pb_notifications/Resources/Private/Language/locallang.xlf:notifications.list.dateFormat')}" />
 								<br>
 								<strong>{notification.title}</strong>:
 							</span>
@@ -26,7 +26,7 @@
 							<f:else>
 							<span class="text-primary">
 								<i class="fa fa-info"></i>&nbsp;
-								<f:format.date date="{notification.date}" format="{f:translate(key:'notifications.list.dateFormat')}" />
+								<f:format.date date="{notification.date}" format="{f:translate(key:'LLL:EXT:pb_notifications/Resources/Private/Language/locallang.xlf:notifications.list.dateFormat')}" />
 								<br>
 								<strong>{notification.title}</strong>:
 							</span>
@@ -45,7 +45,7 @@
 			<f:if condition="{pb:countUnreadNotifications(notifications:'{onlyUnreadNotifications}')} > {maxNumberOfNotificationsInToolbar}">
 
 				<li class="divider"></li>
-				<li><em><f:translate key="toolbaritem.andMore" /></em></li>
+				<li><em><f:translate key="LLL:EXT:pb_notifications/Resources/Private/Language/locallang.xlf:toolbaritem.andMore" /></em></li>
 
 			</f:if>
 
@@ -53,7 +53,7 @@
 
 		<!-- No notifications exist -->
 		<f:else>
-			<li><em><f:translate key="toolbaritem.noNotifications" /></em></li>
+			<li><em><f:translate key="LLL:EXT:pb_notifications/Resources/Private/Language/locallang.xlf:toolbaritem.noNotifications" /></em></li>
 		</f:else>
 
 	</f:if>
@@ -62,8 +62,25 @@
 	<li class="divider"></li>
 
 	<li id="pbnotifications_listnotifications">
-		<a href="#" onclick="top.goToModule('user_PbNotificationsNotifications');">
-			<span class="text-warning"><i class="fa fa-list"></i>&nbsp; <f:translate key="toolbaritem.allNotifications" /></span>
+        <f:comment>
+            TYPO3 v12 top.gotToModule is deprecated in v11 and removed in v12
+            Deprecation: #94058 - JavaScript goToModule()
+            https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.3/Deprecation-94058-JavaScriptGoToModule.html
+
+            Use the following HTML code to replace the inline goToModule() call to for example link to the page module:
+
+            <a href="#"
+               data-dispatch-action="TYPO3.ModuleMenu.showModule"
+               data-dispatch-args-list="web_layout"
+            >
+                Go to page module
+            </a>
+        </f:comment>
+		<a href="#"
+           data-dispatch-action="TYPO3.ModuleMenu.showModule"
+           data-dispatch-args-list="user_PbNotificationsNotifications"
+           >
+			<span class="text-warning"><i class="fa fa-list"></i>&nbsp; <f:translate key="toolbaritem.allNotifications" extensionName="pb_notifications" /></span>
 		</a>
 	</li>
 

--- a/Resources/Private/Templates/ToolbarMenu/DropDown.html
+++ b/Resources/Private/Templates/ToolbarMenu/DropDown.html
@@ -1,8 +1,25 @@
 {namespace pb=PeterBenke\PbNotifications\ViewHelpers}
 
-<h3 class="dropdown-headline"><f:translate key="LLL:EXT:pb_notifications/Resources/Private/Language/locallang.xlf:toolbaritem.title" /></h3>
+<f:comment>
+    Since TYPO3 v12 use:
 
-<ul class="dropdown-list" style="width:250px;">
+    headline: p class="h3 dropdown-headline"
+    divider: hr class="dropdown-divider" aria-hidden="true"
+    items:
+      - ul class="dropdown-list">
+        - li
+           - a class="dropdown-item"
+              - span class="dropdown-item-columns"
+                 - span class="dropdown-item-column"
+                   - icon: span class="t3js-icon icon icon-size-small icon-state-default
+                   - header: class="dropdown-item-column dropdown-item-column-title"
+</f:comment>
+
+<p class="h3 dropdown-headline"><f:translate key="LLL:EXT:pb_notifications/Resources/Private/Language/locallang.xlf:toolbaritem.title" /></p>
+<hr class="dropdown-divider" aria-hidden="true">
+
+
+<ul class="dropdown-list">
 
 	<f:if condition="{onlyUnreadNotifications -> f:count()} > 0">
 
@@ -11,31 +28,35 @@
 			<f:for each="{onlyUnreadNotifications}" as="notification" iteration="iteration">
 
 				<f:if condition="{iteration.index} < {maxNumberOfNotificationsInToolbar}">
-
-					<li class="divider"></li>
 					<li>
-						<f:if condition="{notification.type} == 1">
-							<f:then>
-							<span class="text-danger">
-								<i class="fa fa-exclamation"></i>&nbsp;
-								<f:format.date date="{notification.date}" format="{f:translate(key:'LLL:EXT:pb_notifications/Resources/Private/Language/locallang.xlf:notifications.list.dateFormat')}" />
-								<br>
-								<strong>{notification.title}</strong>:
-							</span>
-							</f:then>
-							<f:else>
-							<span class="text-primary">
-								<i class="fa fa-info"></i>&nbsp;
-								<f:format.date date="{notification.date}" format="{f:translate(key:'LLL:EXT:pb_notifications/Resources/Private/Language/locallang.xlf:notifications.list.dateFormat')}" />
-								<br>
-								<strong>{notification.title}</strong>:
-							</span>
-							</f:else>
-						</f:if>
-						<br>
-						<f:format.crop maxCharacters="45" respectWordBoundaries="false">
-							{notification.content -> f:format.stripTags()}
-						</f:format.crop>
+                        <a href="#" class="dropdown-item"
+                           data-dispatch-action="TYPO3.ModuleMenu.showModule"
+                           data-dispatch-args-list="user_PbNotificationsNotifications"
+                            >
+
+                                <f:if condition="{notification.type} == 1">
+                                    <f:then>
+                                    <span class="text-danger">
+                                        <i class="fa fa-exclamation"></i>&nbsp;
+                                        <f:format.date date="{notification.date}" format="{f:translate(key:'LLL:EXT:pb_notifications/Resources/Private/Language/locallang.xlf:notifications.list.dateFormat')}" />
+                                        <br>
+                                        <strong>{notification.title}</strong>:
+                                    </span>
+                                    </f:then>
+                                    <f:else>
+                                    <span class="text-primary">
+                                        <i class="fa fa-info"></i>&nbsp;
+                                        <f:format.date date="{notification.date}" format="{f:translate(key:'LLL:EXT:pb_notifications/Resources/Private/Language/locallang.xlf:notifications.list.dateFormat')}" />
+                                        <br>
+                                        <strong>{notification.title}</strong>:
+                                    </span>
+                                    </f:else>
+                                </f:if>
+                                <f:format.crop maxCharacters="45" respectWordBoundaries="false">
+                                    {notification.content -> f:format.stripTags()}
+                                </f:format.crop>
+
+                        </a>
 					</li>
 
 				</f:if>
@@ -43,8 +64,6 @@
 			</f:for>
 
 			<f:if condition="{pb:countUnreadNotifications(notifications:'{onlyUnreadNotifications}')} > {maxNumberOfNotificationsInToolbar}">
-
-				<li class="divider"></li>
 				<li><em><f:translate key="LLL:EXT:pb_notifications/Resources/Private/Language/locallang.xlf:toolbaritem.andMore" /></em></li>
 
 			</f:if>
@@ -57,17 +76,17 @@
 		</f:else>
 
 	</f:if>
+</ul>
 
+<hr class="dropdown-divider" aria-hidden="true">
 
-	<li class="divider"></li>
-
-	<li id="pbnotifications_listnotifications">
-		<a href="#"
+<ul class="dropdown-list">
+    <li id="pbnotifications_listnotifications">
+        <a href="#" class="dropdown-item"
            data-dispatch-action="TYPO3.ModuleMenu.showModule"
            data-dispatch-args-list="user_PbNotificationsNotifications"
-           >
-			<span class="text-warning"><i class="fa fa-list"></i>&nbsp; <f:translate key="toolbaritem.allNotifications" extensionName="pb_notifications" /></span>
-		</a>
-	</li>
-
+        >
+            <span class="text-warning"><i class="fa fa-list"></i>&nbsp; <f:translate key="toolbaritem.allNotifications" extensionName="pb_notifications" /></span>
+        </a>
+    </li>
 </ul>

--- a/Resources/Private/Templates/ToolbarMenu/DropDown.html
+++ b/Resources/Private/Templates/ToolbarMenu/DropDown.html
@@ -71,7 +71,12 @@
 
 		<!-- No notifications exist -->
 		<f:else>
-			<li><em><f:translate key="LLL:EXT:pb_notifications/Resources/Private/Language/locallang.xlf:toolbaritem.noNotifications" /></em></li>
+			<li>
+                <span class="dropdown-item">
+                    <f:translate key="LLL:EXT:pb_notifications/Resources/Private/Language/locallang.xlf:toolbaritem.noNotifications" />
+                </span>
+            </li>
+
 		</f:else>
 
 	</f:if>

--- a/Resources/Private/Templates/ToolbarMenu/DropDown.html
+++ b/Resources/Private/Templates/ToolbarMenu/DropDown.html
@@ -33,11 +33,10 @@
                            data-dispatch-action="TYPO3.ModuleMenu.showModule"
                            data-dispatch-args-list="user_PbNotificationsNotifications"
                             >
-
-                                <f:if condition="{notification.type} == 1">
+                               <f:if condition="{notification.type} == 1">
                                     <f:then>
                                     <span class="text-danger">
-                                        <i class="fa fa-exclamation"></i>&nbsp;
+                                        <core:icon identifier="actions-exclamation-circle-alt"/>&nbsp;
                                         <f:format.date date="{notification.date}" format="{f:translate(key:'LLL:EXT:pb_notifications/Resources/Private/Language/locallang.xlf:notifications.list.dateFormat')}" />
                                         <br>
                                         <strong>{notification.title}</strong>:
@@ -45,7 +44,7 @@
                                     </f:then>
                                     <f:else>
                                     <span class="text-primary">
-                                        <i class="fa fa-info"></i>&nbsp;
+                                        <core:icon identifier="actions-info-circle"/>&nbsp;
                                         <f:format.date date="{notification.date}" format="{f:translate(key:'LLL:EXT:pb_notifications/Resources/Private/Language/locallang.xlf:notifications.list.dateFormat')}" />
                                         <br>
                                         <strong>{notification.title}</strong>:

--- a/Resources/Private/Templates/ToolbarMenu/MenuItem.html
+++ b/Resources/Private/Templates/ToolbarMenu/MenuItem.html
@@ -3,14 +3,14 @@
 
 <f:if condition="{pb:countUnreadNotifications(notifications:'{notifications}')} > 0">
 	<f:then>
-		<span title="{f:translate(key:'toolbaritem.title')}">
+		<span title="{f:translate(key:'LLL:EXT:pb_notifications/Resources/Private/Language/locallang.xlf:toolbaritem.title')}">
 			<core:icon identifier="apps-toolbar-menu-pbnotifications-alert" size="small" />
 		</span>
 		<span id="tx-pbnotifications-counter" class="badge badge-danger" style="display: inline;"><pb:countUnreadNotifications notifications="{notifications}" /></span>
 	</f:then>
 
 	<f:else>
-		<span title="{f:translate(key:'toolbaritem.title')}">
+		<span title="{f:translate(key:'LLL:EXT:pb_notifications/Resources/Private/Language/locallang.xlf:toolbaritem.title')}">
 			<core:icon identifier="apps-toolbar-menu-pbnotifications" size="small" />
 		</span>
 	</f:else>

--- a/Resources/Public/JavaScript/List/notifications.js
+++ b/Resources/Public/JavaScript/List/notifications.js
@@ -1,3 +1,25 @@
+define(['jquery'], function($) {
+
+
+  $(document).ready(function () {
+    // on load
+    //console.log('hallo');
+    if($("a[rel^='prettyPhoto']").length){
+      $("a[rel^='prettyPhoto']").prettyPhoto({
+        show_title: false,
+        social_tools: false
+      });
+    }
+
+    $('.panel-body a[href^="http"]:not(a[rel^="prettyPhoto"]):not(a[href$=".zip"])').each(function(){
+      $(this).attr('target', '_blank');
+    });
+
+  });
+
+});
+
+/*
 $(document).ready(function() {
 
 	if($("a[rel^='prettyPhoto']").length){
@@ -12,3 +34,5 @@ $(document).ready(function() {
 	});
 
 });
+
+ */

--- a/Resources/Public/JavaScript/Reminder/Reminder.js
+++ b/Resources/Public/JavaScript/Reminder/Reminder.js
@@ -1,5 +1,9 @@
 /**
  * Reminder for the notifications
+ *
+ * Changes for TYPO3 v12:
+ *   Breaking: #98288 - Updated Backend Modal API
+ *   https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Breaking-98288-UpdatedBackendModalAPI.html
  */
 define(['jquery', 'TYPO3/CMS/Backend/Modal'], function ($, Modal) {
 
@@ -10,24 +14,47 @@ define(['jquery', 'TYPO3/CMS/Backend/Modal'], function ($, Modal) {
     Reminder.initModal = function (force) {
 
         $(function () {
-			Modal.show(
-				TYPO3.lang['reminder.title'],
-				TYPO3.lang['reminder.message'],
-				TYPO3.Severity.warning,
-				[{
-					text: TYPO3.lang['button.ok'] || 'OK',
-					btnClass: 'btn-warning',
-					name: 'ok',
-					active: true
-				}]
-			).on('button.clicked', function () {
-				Modal.currentModal.trigger('modal-dismiss');
-			}).on('hidden.bs.modal', function () {
-				top.goToModule('user_PbNotificationsNotifications');
-			});
+
+          const modal = Modal.show(
+            TYPO3.lang['reminder.title'],
+            TYPO3.lang['reminder.message'],
+            TYPO3.Severity.warning,
+            [
+              {
+                text: TYPO3.lang['button.ok'] || 'OK',
+                btnClass: 'btn-warning',
+                name: 'ok',
+                active: true,
+                trigger: function(event, modal) {
+                  modal.hideModal();
+                }
+              }
+              ]
+          );
+
+          modal.addEventListener('hidden.bs.modal', function() {
+            console.log('pb_notifications: Reminder: in Modal: hidden.bs.modal');
+            /**
+             * @todo go to module user_PbNotificationsNotifications
+             *
+             * TYPO3 v12 top.gotToModule is deprecated in v11 and removed in v12
+             * Deprecation: #94058 - JavaScript goToModule()
+             * https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.3/Deprecation-94058-JavaScriptGoToModule.html
+             * Use the following HTML code to replace the inline goToModule() call to for example link to the page module:
+             *
+             * <a href="#"
+             *   data-dispatch-action="TYPO3.ModuleMenu.showModule"
+             *   data-dispatch-args-list="web_layout"
+             *   >
+             *   Go to page module
+             *   </a>
+             */
+             //top.goToModule('user_PbNotificationsNotifications');
+         });
+
         });
     };
 
-    return Reminder;
+  return Reminder;
 
 });

--- a/Resources/Public/JavaScript/Reminder/Reminder.js
+++ b/Resources/Public/JavaScript/Reminder/Reminder.js
@@ -33,23 +33,7 @@ define(['jquery', 'TYPO3/CMS/Backend/Modal'], function ($, Modal) {
           );
 
           modal.addEventListener('hidden.bs.modal', function() {
-            console.log('pb_notifications: Reminder: in Modal: hidden.bs.modal');
-            /**
-             * @todo go to module user_PbNotificationsNotifications
-             *
-             * TYPO3 v12 top.gotToModule is deprecated in v11 and removed in v12
-             * Deprecation: #94058 - JavaScript goToModule()
-             * https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.3/Deprecation-94058-JavaScriptGoToModule.html
-             * Use the following HTML code to replace the inline goToModule() call to for example link to the page module:
-             *
-             * <a href="#"
-             *   data-dispatch-action="TYPO3.ModuleMenu.showModule"
-             *   data-dispatch-args-list="web_layout"
-             *   >
-             *   Go to page module
-             *   </a>
-             */
-             //top.goToModule('user_PbNotificationsNotifications');
+            TYPO3.ModuleMenu.App.showModule('user_PbNotificationsNotifications');
          });
 
         });

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "GPL-2.0+"
     ],
     "require": {
-        "typo3/cms-core": "^11.5"
+        "typo3/cms-core": "^12.4"
     },
     "autoload": {
         "psr-4": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -7,10 +7,10 @@ $EM_CONF[$_EXTKEY] = [
 	'author' => 'Peter Benke',
 	'author_email' => 'info@typomotor.de',
 	'state' => 'stable',
-	'version' => '11.5.1',
+	'version' => '12.0.0-dev',
 	'constraints' => [
 		'depends' => [
-			'typo3' => '11.5.0-11.5.99',
+			'typo3' => '12.4.19-12.4.99',
 		],
 		'conflicts' => [],
 		'suggests' => [],

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -11,19 +11,47 @@ use PeterBenke\PbNotifications\Hook\BackendHook;
  */
 use TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider;
 use TYPO3\CMS\Core\Imaging\IconRegistry;
+use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 defined('TYPO3') or die();
 
 $boot = static function (): void {
 
-	// Toolbar
-	// -----------------------------------------------------------------------------------------------------------------
-	$GLOBALS['TYPO3_CONF_VARS']['BE']['toolbarItems'][1481194871] = NotificationsToolbarItem::class;
+    /** @var Typo3Version $typoVersion */
+    $typoVersion = GeneralUtility::makeInstance(Typo3Version::class);
+    if ($typoVersion->getMajorVersion() < 12) {
 
-	// Reminder after login
-	// -----------------------------------------------------------------------------------------------------------------
-	$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['typo3/backend.php']['constructPostProcess']['pb_notifications'] = BackendHook::class . '->constructPostProcess';
+        // Toolbar
+        // -----------------------------------------------------------------------------------------------------------------
+
+        /**
+         * DONE
+         * Should be ok for v12 with autoconfigure in Services.yaml
+         *
+         * breaking in v12: (remove)
+         *  12.0 Breaking: #96041 - Toolbar items: Register by tag
+         *
+         * Remove $GLOBALS['TYPO3_CONF_VARS']['BE']['toolbarItems']  from your ext_localconf.php file. If autoconfigure is not enabled in your Configuration/Services.(yaml|php), add the tag backend.toolbar.item to your toolbar item class.
+         */
+        $GLOBALS['TYPO3_CONF_VARS']['BE']['toolbarItems'][1481194871] = NotificationsToolbarItem::class;
+
+
+        // Reminder after login
+        // -----------------------------------------------------------------------------------------------------------------
+
+
+        /**
+         * @todo Add replacement for v12
+         *
+         * breaking in v12: (remove)
+         *  12.0 Breaking: #97451 - Removed BackendController page hooks
+         *  12.0 Feature: #97451 - PSR-14 events for modifying backend page content
+         *
+         * Hook is removed, use event \TYPO3\CMS\Backend\Controller\Event\AfterBackendPageRenderEvent
+         */
+        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['typo3/backend.php']['constructPostProcess']['pb_notifications'] = BackendHook::class . '->constructPostProcess';
+    }
 
 	// Register icons
 	// -----------------------------------------------------------------------------------------------------------------

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -22,21 +22,6 @@ $boot = static function (): void {
     $typoVersion = GeneralUtility::makeInstance(Typo3Version::class);
     if ($typoVersion->getMajorVersion() < 12) {
 
-        // Toolbar
-        // -----------------------------------------------------------------------------------------------------------------
-
-        /**
-         * DONE
-         * Should be ok for v12 with autoconfigure in Services.yaml
-         *
-         * breaking in v12: (remove)
-         *  12.0 Breaking: #96041 - Toolbar items: Register by tag
-         *
-         * Remove $GLOBALS['TYPO3_CONF_VARS']['BE']['toolbarItems']  from your ext_localconf.php file. If autoconfigure is not enabled in your Configuration/Services.(yaml|php), add the tag backend.toolbar.item to your toolbar item class.
-         */
-        $GLOBALS['TYPO3_CONF_VARS']['BE']['toolbarItems'][1481194871] = NotificationsToolbarItem::class;
-
-
         // Reminder after login
         // -----------------------------------------------------------------------------------------------------------------
 

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -25,20 +25,6 @@ $boot = static function (): void {
      */
     ExtensionManagementUtility::addLLrefForTCAdescr('tx_pbnotifications_domain_model_notification', 'EXT:pb_notifications/Resources/Private/Language/locallang_csh_tx_pbnotifications_domain_model_notification.xlf');
 
-    /**
-     * @todo Replace once support for v11 is dropped
-     *
-     * deprecated in v12: The API method :php:`ExtensionManagementUtility::allowTableOnStandardPages` which
-     * was used in `ext_tables.php` files of extensions registering custom records available
-     * on any page type has been marked as deprecated.
-     *
-     * see
-     *  12.0 Breaking: #98487 - $GLOBALS['PAGES_TYPES'] removed
-     *  12.0 Deprecation: #98487 - ExtensionManagementUtility::allowTableOnStandardPages
-     *  12.0 Feature: #98487 - TCA option [ctrl][security][ignorePageTypeRestriction]
-     */
-    ExtensionManagementUtility::allowTableOnStandardPages('tx_pbnotifications_domain_model_notification');
-
     /** @var Typo3Version $typoVersion */
     $typoVersion = GeneralUtility::makeInstance(Typo3Version::class);
 

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -8,7 +8,10 @@ use PeterBenke\PbNotifications\Backend\ToolbarItems\NotificationsToolbarItem;
 /**
  * TYPO3
  */
+
+use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
 
 
@@ -16,25 +19,53 @@ defined('TYPO3') or die();
 
 $boot = static function (): void {
 
-	ExtensionManagementUtility::addLLrefForTCAdescr('tx_pbnotifications_domain_model_notification', 'EXT:pb_notifications/Resources/Private/Language/locallang_csh_tx_pbnotifications_domain_model_notification.xlf');
-	ExtensionManagementUtility::allowTableOnStandardPages('tx_pbnotifications_domain_model_notification');
+    /**
+     * @todo: addLLrefForTCAdescr is deprecated in v12
+     *   Deprecation: #97312 - Deprecate CSH-related methods
+     */
+    ExtensionManagementUtility::addLLrefForTCAdescr('tx_pbnotifications_domain_model_notification', 'EXT:pb_notifications/Resources/Private/Language/locallang_csh_tx_pbnotifications_domain_model_notification.xlf');
 
-	// Register the backend module
-	ExtensionUtility::registerModule(
-		'pb_notifications',
-		'user',     // Make module a submodule of 'user'
-		'notifications',    // Submodule key
-		'',                        // Position
-		[
-			\PeterBenke\PbNotifications\Controller\NotificationController::class => 'list, show, markAsRead, markAsUnread',
-		],
-		[
-			'access' => 'user,group',
-			'icon' => 'EXT:pb_notifications/Resources/Public/Icons/bell-orange.svg',
-			'labels' => 'LLL:EXT:pb_notifications/Resources/Private/Language/locallang.xlf:module.notifications.title',
-		]
-	);
+    /**
+     * @todo Replace once support for v11 is dropped
+     *
+     * deprecated in v12: The API method :php:`ExtensionManagementUtility::allowTableOnStandardPages` which
+     * was used in `ext_tables.php` files of extensions registering custom records available
+     * on any page type has been marked as deprecated.
+     *
+     * see
+     *  12.0 Breaking: #98487 - $GLOBALS['PAGES_TYPES'] removed
+     *  12.0 Deprecation: #98487 - ExtensionManagementUtility::allowTableOnStandardPages
+     *  12.0 Feature: #98487 - TCA option [ctrl][security][ignorePageTypeRestriction]
+     */
+    ExtensionManagementUtility::allowTableOnStandardPages('tx_pbnotifications_domain_model_notification');
 
+    /** @var Typo3Version $typoVersion */
+    $typoVersion = GeneralUtility::makeInstance(Typo3Version::class);
+
+    if ($typoVersion->getMajorVersion() < 12) {
+
+        /**
+         * DONE (see Configuration/Modules.php for v12)
+         *
+         * Register the backend module
+         * breaking in v12 (remove):
+         *   12.0  Breaking: #96733 - Removed support for module handling based on TBE_MODULES
+         */
+        ExtensionUtility::registerModule(
+            'pb_notifications',
+            'user',     // Make module a submodule of 'user'
+            'notifications',    // Submodule key
+            '',                        // Position
+            [
+                \PeterBenke\PbNotifications\Controller\NotificationController::class => 'list, show, markAsRead, markAsUnread',
+            ],
+            [
+                'access' => 'user,group',
+                'icon' => 'EXT:pb_notifications/Resources/Public/Icons/bell-orange.svg',
+                'labels' => 'LLL:EXT:pb_notifications/Resources/Private/Language/locallang.xlf:module.notifications.title',
+            ]
+        );
+    }
 
 	/*
 


### PR DESCRIPTION
Support for v11 is dropped

Resolves: #8

----

Functionality basically works. Probably needs some more work and tests. I originally planned to keep support for v11 and added version switches (with Typo3Version), but there are 1 or 2 places which might not work with v11 (not entirely sure), so I think it would be safer to drop v11 support with this change. 

Also, using some PHP 8 constructs, so support for PHP 7 should be dropped (which is implicit if TYPO3 version requirement is ^12).

There are still some todos in the code.